### PR TITLE
update ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: devel
+    schedule:
+      interval: monthly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
       # conda
       - if: matrix.pm == 'conda'
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
       - if: matrix.pm == 'conda'
         run: conda install -n test -c conda-forge pinocchio
       - if: matrix.pm == 'conda'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
         run: nix-channel --update
       - if: matrix.pm == 'nix'
         run: >
-          nix shell   'nixpkgs#python310Packages.pinocchio' -c
-          nix develop 'nixpkgs#python310Packages.pinocchio' -c
+          nix shell   'nixpkgs#python311Packages.pinocchio' -c
+          nix develop 'nixpkgs#python311Packages.pinocchio' -c
           env | grep .=. >> $GITHUB_ENV
 
       # robotpkg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     name: "Test ${{ matrix.pm }} on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}-latest"
     strategy:
+      fail-fast: false
       matrix:
         pm: ["pip", "conda", "nix"]
         os: ["ubuntu", "macos", "windows"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(PROJECT_URL "http://github.com/stack-of-tasks/${PROJECT_NAME}")
 project(${PROJECT_NAME})
 
 # pinocchio dependency
-find_package(pinocchio 2.7.0 REQUIRED)
+find_package(pinocchio REQUIRED)
 
 # Create the main executable
 add_executable(main main.cpp)


### PR DESCRIPTION
- conda CI is failing because of https://github.com/conda-forge/qhull-feedstock/pull/19, but this doesn't have to make everything else fail fast
- ROS is still on 2.6.11, and nix is on 3.0.0, but everything still works as expected on those versions, so there is no need to add version constraints
- update nix to python 3.11
- update conda action (v2 was failing)
- setup dependabot to update actions